### PR TITLE
remove-overflow:hidden

### DIFF
--- a/src/styles/qualtrics.css
+++ b/src/styles/qualtrics.css
@@ -26,7 +26,7 @@ input::placeholder {
 
 .MainContent {
   flex: 1 0 0;
-  overflow: hidden;
+  
 }
 
 .Layout {


### PR DESCRIPTION
remove overflow:hidden option from CSS for maincontent to fix vertical scroll